### PR TITLE
haarcascade_frontalface_default.xml 로드 중에 발생하는 오류 제거

### DIFF
--- a/OSS_UI/OSS_project.py
+++ b/OSS_UI/OSS_project.py
@@ -131,8 +131,10 @@ def main(haar_cascade_filepath):
 
 if __name__ == '__main__':
     script_dir = path.dirname(path.realpath(__file__))
-    cascade_filepath = path.join(script_dir,
-                                 'data',
+    xmls_dir = path.join(script_dir,
+                         '..',
+                         'xmls')
+    cascade_filepath = path.join(xmls_dir,
                                  'haarcascade_frontalface_default.xml')
 
     cascade_filepath = path.abspath(cascade_filepath)


### PR DESCRIPTION
기존 프로젝트에서 OSS_UI/OSS_project.py 를 실행하고 start 버튼을 누르면 아래의 오류가 발생했습니다.
```
Traceback (most recent call last):
  File "OSS_project.py", line 58, in image_data_slot
    faces = self.detect_faces(image_data)
  File "OSS_project.py", line 53, in detect_faces
    minSize=self._min_size)
cv2.error: OpenCV(3.4.2) C:\projects\opencv-python\opencv\modules\objdetect\src\cascadedetect.cpp:1698: error: (-215:Assertion failed) !empty() in function 'cv::CascadeClassifier::detectMultiScale'
```

해당 오류의 근본적인 원인은 haarcascade_frontalface_default.xml 로드에 실패했기 때문입니다.  
이 PR은 오류를 제거하여 xml이 정상적으로 로드될 수 있도록 만듭니다.  
오류 없이 정상적으로 캠 화면이 출력되는 것을 확인했습니다.

Tested on Python 3.6